### PR TITLE
feat: remove protected storage/memory

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -533,7 +533,8 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 
 // Create creates a new contract using code as deployment code.
 func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
-	return fhevm.Create(evm.FhevmEnvironment(), caller.Address(), code, gas, value)
+	contractAddr = crypto.CreateAddress(caller.Address(), evm.StateDB.GetNonce(caller.Address()))
+	return evm.create(caller, &codeAndHash{code: code}, gas, value, contractAddr, CREATE)
 }
 
 // Create2 creates a new contract using code as deployment code.
@@ -541,7 +542,9 @@ func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.I
 // The different between Create2 with Create is Create2 uses keccak256(0xff ++ msg.sender ++ salt ++ keccak256(init_code))[12:]
 // instead of the usual sender-and-nonce-hash as the address where the contract is initialized at.
 func (evm *EVM) Create2(caller ContractRef, code []byte, gas uint64, endowment *big.Int, salt *uint256.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
-	return fhevm.Create2(evm.FhevmEnvironment(), caller.Address(), code, gas, endowment, salt)
+	codeAndHash := &codeAndHash{code: code}
+	contractAddr = crypto.CreateAddress2(caller.Address(), salt.Bytes32(), codeAndHash.Hash().Bytes())
+	return evm.create(caller, codeAndHash, gas, endowment, contractAddr, CREATE2)
 }
 
 // ChainConfig returns the environment's chain configuration

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -134,10 +134,6 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 	// Increment the call depth which is restricted to 1024
 	in.evm.depth++
 	defer func() {
-		_, span := otel.Tracer("fhevm").Start(ctx, "RemoveVerifiedCipherextsAtCurrentDepth")
-		fhevm.RemoveVerifiedCipherextsAtCurrentDepth(in.evm.FhevmEnvironment())
-		span.End()
-
 		in.evm.depth--
 	}()
 

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -59,8 +59,9 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 		}
 		// TODO: For now, every SSTORE referring to a ciphertext incurs the same cost, irrespective
 		// of the original and current values of the storage slot. Refunds for ciphertexts are not taken into account.
-		if t := fhevm.GetTypeOfVerifiedCiphertext(evm.FhevmEnvironment(), value); t != nil {
-			cost += evm.fhevmEnvironment.params.GasCosts.ProtectedStorageSstoreGas[*t]
+		ct := fhevm.GetCiphertextFromMemory(evm.FhevmEnvironment(), value)
+		if ct != nil {
+			cost += evm.fhevmEnvironment.params.GasCosts.FheStorageSstoreGas[ct.Type()]
 		}
 		original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 		if original == current {


### PR DESCRIPTION
First phase of changing fhEVM to use an ACL contract. Integrates the fhevm-go version that no longer uses protected storage and memory.