### PR TITLE
feat: create ciphertext storage on CREATE/CREATE2

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -534,6 +534,11 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 // Create creates a new contract using code as deployment code.
 func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
 	contractAddr = crypto.CreateAddress(caller.Address(), evm.StateDB.GetNonce(caller.Address()))
+	// Create the ciphertext storage if not already created.
+	if evm.StateDB.GetNonce(fhevm.CiphertextStorageAddress) == 0 {
+		evm.StateDB.CreateAccount(fhevm.CiphertextStorageAddress)
+		evm.StateDB.SetNonce(fhevm.CiphertextStorageAddress, 1)
+	}
 	return evm.create(caller, &codeAndHash{code: code}, gas, value, contractAddr, CREATE)
 }
 
@@ -544,6 +549,11 @@ func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.I
 func (evm *EVM) Create2(caller ContractRef, code []byte, gas uint64, endowment *big.Int, salt *uint256.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
 	codeAndHash := &codeAndHash{code: code}
 	contractAddr = crypto.CreateAddress2(caller.Address(), salt.Bytes32(), codeAndHash.Hash().Bytes())
+	// Create the ciphertext storage if not already created.
+	if evm.StateDB.GetNonce(fhevm.CiphertextStorageAddress) == 0 {
+		evm.StateDB.CreateAccount(fhevm.CiphertextStorageAddress)
+		evm.StateDB.SetNonce(fhevm.CiphertextStorageAddress, 1)
+	}
 	return evm.create(caller, codeAndHash, gas, endowment, contractAddr, CREATE2)
 }
 


### PR DESCRIPTION
Some storage backends (e.g. geth) require that the ciphertext storage contract account is explicitly created. We do that only once on CREATE and CREATE2 by initially setting its nonce from 0 to 1 and subsequently not doing anything if nonce is not 0.

Above is not required for Ethermint, for example, but it doesn't impact it either.